### PR TITLE
android: applets: Fix button order received from button_text

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/applets/SoftwareKeyboard.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/applets/SoftwareKeyboard.java
@@ -147,7 +147,7 @@ public final class SoftwareKeyboard {
                 case ButtonConfig.Single: {
                     final String text = config.button_text == null
                             ? emulationActivity.getString(android.R.string.ok)
-                            : config.button_text[config.button_config];
+                            : config.button_text[2];
                     builder.setPositiveButton(text, null);
                     break;
                 }


### PR DESCRIPTION
Fixes [#5359](https://github.com/citra-emu/citra/issues/5359) for android
Equivalent of PR [#5362](https://github.com/citra-emu/citra/pull/5362) in citra-emu/citra

Apps always return 3 strings, even if there is no custom text, so the index should be constant for each button.

The "OK" button is always at index 2.