### PR TITLE
Touchscreen Fix

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlay.java
@@ -340,7 +340,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener {
         int pointerIndex = event.getActionIndex();
 
         if (mPreferences.getBoolean("isTouchEnabled", true)) {
-            switch (event.getAction()) {
+            switch (event.getAction() & MotionEvent.ACTION_MASK) {
                 case MotionEvent.ACTION_DOWN:
                 case MotionEvent.ACTION_POINTER_DOWN:
                     NativeLibrary.onTouchEvent(event.getX(pointerIndex), event.getY(pointerIndex), true);


### PR DESCRIPTION
Should fix #47

Originally, since the ACTION_MASK was not applied, the switch case only worked when the pointer index was 0. It should now fix the issue where touches on the 3DS touch screen were not detected.
