### PR TITLE
Make touch joystick re-centering configurable

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
@@ -66,6 +66,7 @@ public final class EmulationActivity extends AppCompatActivity {
     public static final int MENU_ACTION_OPEN_SETTINGS = 12;
     public static final int MENU_ACTION_LOAD_AMIIBO = 13;
     public static final int MENU_ACTION_REMOVE_AMIIBO = 14;
+    public static final int MENU_ACTION_JOYSTICK_REL_CENTER = 15;
 
     public static final int REQUEST_SELECT_AMIIBO = 2;
     private static final int EMULATION_RUNNING_NOTIFICATION = 0x1000;
@@ -100,6 +101,8 @@ public final class EmulationActivity extends AppCompatActivity {
                 .append(R.id.menu_emulation_amiibo_load, EmulationActivity.MENU_ACTION_LOAD_AMIIBO);
         buttonsActionsMap
                 .append(R.id.menu_emulation_amiibo_remove, EmulationActivity.MENU_ACTION_REMOVE_AMIIBO);
+        buttonsActionsMap.append(R.id.menu_emulation_joystick_rel_center,
+                EmulationActivity.MENU_ACTION_JOYSTICK_REL_CENTER);
     }
 
     private View mDecorView;
@@ -299,6 +302,7 @@ public final class EmulationActivity extends AppCompatActivity {
         }
 
         menu.findItem(layoutOptionMenuItem).setChecked(true);
+        menu.findItem(R.id.menu_emulation_joystick_rel_center).setChecked(EmulationMenuSettings.getJoystickRelCenter());
         menu.findItem(R.id.menu_emulation_show_fps).setChecked(EmulationMenuSettings.getShowFps());
         menu.findItem(R.id.menu_emulation_swap_screens).setChecked(EmulationMenuSettings.getSwapScreens());
         menu.findItem(R.id.menu_emulation_show_overlay).setChecked(EmulationMenuSettings.getShowOverlay());
@@ -397,6 +401,12 @@ public final class EmulationActivity extends AppCompatActivity {
 
             case MENU_ACTION_REMOVE_AMIIBO:
                 RemoveAmiibo();
+                break;
+
+            case MENU_ACTION_JOYSTICK_REL_CENTER:
+                final boolean isEnabled = !EmulationMenuSettings.getJoystickRelCenter();
+                EmulationMenuSettings.setJoystickRelCenter(isEnabled);
+                item.setChecked(isEnabled);
                 break;
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.view.MotionEvent;
 
 import org.citra.citra_emu.NativeLibrary.ButtonType;
+import org.citra.citra_emu.utils.EmulationMenuSettings;
 
 /**
  * Custom {@link BitmapDrawable} that is capable
@@ -98,8 +99,10 @@ public final class InputOverlayDrawableJoystick {
                     mPressedState = true;
                     mOuterBitmap.setAlpha(0);
                     mBoundsBoxBitmap.setAlpha(255);
-                    getVirtBounds().offset((int) event.getX(pointerIndex) - getVirtBounds().centerX(),
-                            (int) event.getY(pointerIndex) - getVirtBounds().centerY());
+                    if (EmulationMenuSettings.getJoystickRelCenter()) {
+                        getVirtBounds().offset((int) event.getX(pointerIndex) - getVirtBounds().centerX(),
+                                (int) event.getY(pointerIndex) - getVirtBounds().centerY());
+                    }
                     mBoundsBoxBitmap.setBounds(getVirtBounds());
                     trackId = event.getPointerId(pointerIndex);
                 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/EmulationMenuSettings.java
@@ -16,6 +16,16 @@ public class EmulationMenuSettings {
     public static final int LayoutOption_MobilePortrait = 4;
     public static final int LayoutOption_MobileLandscape = 5;
 
+    public static boolean getJoystickRelCenter() {
+        return mPreferences.getBoolean("EmulationMenuSettings_JoystickRelCenter", true);
+    }
+
+    public static void setJoystickRelCenter(boolean value) {
+        final SharedPreferences.Editor editor = mPreferences.edit();
+        editor.putBoolean("EmulationMenuSettings_JoystickRelCenter", value);
+        editor.apply();
+    }
+
     public static int getLandscapeScreenLayout() {
         return mPreferences.getInt("EmulationMenuSettings_LandscapeScreenLayout", LayoutOption_MobileLandscape);
     }

--- a/src/android/app/src/main/res/menu/menu_emulation.xml
+++ b/src/android/app/src/main/res/menu/menu_emulation.xml
@@ -19,6 +19,13 @@
                 android:id="@+id/menu_emulation_adjust_scale"
                 android:title="@string/emulation_control_scale" />
 
+            <group android:checkableBehavior="all">
+                <item
+                    android:id="@+id/menu_emulation_joystick_rel_center"
+                    android:checkable="true"
+                    android:title="@string/emulation_control_joystick_rel_center"/>
+            </group>
+
             <item
                 android:id="@+id/menu_emulation_reset_overlay"
                 android:title="@string/emulation_touch_overlay_reset" />

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -137,6 +137,7 @@
     <string name="emulation_done">Done</string>
     <string name="emulation_toggle_controls">Toggle Controls</string>
     <string name="emulation_control_scale">Adjust Scale</string>
+    <string name="emulation_control_joystick_rel_center">Relative Stick Center</string>
     <string name="emulation_open_settings">Open Settings</string>
     <string name="emulation_switch_screen_layout">Landscape Screen Layout</string>
     <string name="emulation_screen_layout_landscape">Default</string>


### PR DESCRIPTION
Based on dolphin-emu/dolphin#7186.

Adds a new menu option to Configure Controls which configures whether the circle pad re-centers or not.