### PR TITLE
Allow sliding finger across DPad to change direction

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.java
@@ -27,6 +27,7 @@ public final class InputOverlayDrawableDpad {
     public static final int STATE_PRESSED_UP_RIGHT = 6;
     public static final int STATE_PRESSED_DOWN_LEFT = 7;
     public static final int STATE_PRESSED_DOWN_RIGHT = 8;
+    public static final float VIRT_AXIS_DEADZONE = 0.2f;
     // The ID identifying what type of button this Drawable represents.
     private int[] mButtonType = new int[4];
     private int mTrackId;


### PR DESCRIPTION
DPad buttons behave similarly to joystick, you can slide the finger across it to change direction. Might add an option to disable, if necessary. I didn't implement recentering because it seemed more confusing, let me know if I should add it.