### PR TITLE
android: frontend: Start a service to keep the persistent notification

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
 
     <application
@@ -55,6 +56,8 @@
             android:resizeableActivity="false"
             android:theme="@style/CitraEmulationBase"
             android:launchMode="singleTop"/>
+
+        <service android:name="org.citra.citra_emu.utils.ForegroundService"/>
 
         <activity
             android:name="org.citra.citra_emu.activities.CustomFilePickerActivity"

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
@@ -1,7 +1,6 @@
 package org.citra.citra_emu.activities;
 
 import android.app.Activity;
-import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -23,7 +22,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.fragment.app.FragmentActivity;
 
@@ -39,6 +37,7 @@ import org.citra.citra_emu.utils.ControllerMappingHelper;
 import org.citra.citra_emu.utils.EmulationMenuSettings;
 import org.citra.citra_emu.utils.FileBrowserHelper;
 import org.citra.citra_emu.utils.FileUtil;
+import org.citra.citra_emu.utils.ForegroundService;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,6 +105,7 @@ public final class EmulationActivity extends AppCompatActivity {
     private EmulationFragment mEmulationFragment;
     private SharedPreferences mPreferences;
     private ControllerMappingHelper mControllerMappingHelper;
+    private Intent foregroundService;
     private boolean activityRecreated;
     private String mSelectedTitle;
     private String mPath;
@@ -118,30 +118,13 @@ public final class EmulationActivity extends AppCompatActivity {
         activity.startActivity(launcher);
     }
 
-    private void showRunningNotification() {
-        // Intent is used to resume emulation if the notification is clicked
-        PendingIntent contentIntent = PendingIntent.getActivity(this, 0,
-                new Intent(this, EmulationActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
-
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, getString(R.string.app_notification_channel_id))
-                .setSmallIcon(R.drawable.ic_stat_notification_logo)
-                .setContentTitle(getString(R.string.app_name))
-                .setContentText(getString(R.string.app_notification_running))
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setVibrate(null)
-                .setSound(null)
-                .setContentIntent(contentIntent);
-
-        NotificationManagerCompat.from(this).notify(EMULATION_RUNNING_NOTIFICATION, builder.build());
-    }
-
     public static void tryDismissRunningNotification(Activity activity) {
         NotificationManagerCompat.from(activity).cancel(EMULATION_RUNNING_NOTIFICATION);
     }
 
     @Override
     protected void onDestroy() {
-        tryDismissRunningNotification(this);
+        stopService(foregroundService);
         super.onDestroy();
     }
 
@@ -193,7 +176,9 @@ public final class EmulationActivity extends AppCompatActivity {
 
         mPreferences = PreferenceManager.getDefaultSharedPreferences(this);
 
-        showRunningNotification();
+        // Start a foreground service to prevent the app from getting killed in the background
+        foregroundService = new Intent(EmulationActivity.this, ForegroundService.class);
+        startForegroundService(foregroundService);
 
         // Override Citra core INI with the one set by our in game menu
         NativeLibrary.SwapScreens(EmulationMenuSettings.getSwapScreens(),

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/ForegroundService.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/ForegroundService.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2014 Dolphin Emulator Project
+ * Licensed under GPLv2+
+ * Refer to the license.txt file included.
+ */
+
+package org.citra.citra_emu.utils;
+
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+import org.citra.citra_emu.R;
+import org.citra.citra_emu.activities.EmulationActivity;
+
+/**
+ * A service that shows a permanent notification in the background to avoid the app getting
+ * cleared from memory by the system.
+ */
+public class ForegroundService extends Service {
+    private static final int EMULATION_RUNNING_NOTIFICATION = 0x1000;
+
+    private void showRunningNotification() {
+        // Intent is used to resume emulation if the notification is clicked
+        PendingIntent contentIntent = PendingIntent.getActivity(this, 0,
+                new Intent(this, EmulationActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, getString(R.string.app_notification_channel_id))
+                .setSmallIcon(R.drawable.ic_stat_notification_logo)
+                .setContentTitle(getString(R.string.app_name))
+                .setContentText(getString(R.string.app_notification_running))
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .setVibrate(null)
+                .setSound(null)
+                .setContentIntent(contentIntent);
+        startForeground(EMULATION_RUNNING_NOTIFICATION, builder.build());
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        showRunningNotification();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        NotificationManagerCompat.from(this).cancel(EMULATION_RUNNING_NOTIFICATION);
+    }
+}


### PR DESCRIPTION
Resolves #65

Due to how Android handles applications in the background, starting a foreground service is the only way to prevent the system from clearing the app from memory when minimized.

This is also necessary to keep the running notification showing. I noticed that commit b1434f76722959c9c9a4fbcf061c2e78954869db removed the `.setOngoing` property. This had to be re-enabled or else the notification could be manually dismissed, which would imply to the user that emulation is not running (when app is minimized) while the service is still running.