### PR TITLE
video_core/GLES: fix issues cause by missing glTextureBarrier

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -779,6 +779,20 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
         }
     }
 
+    OGLTexture temp_tex;
+    if (need_texture_barrier && GLES) {
+        temp_tex.Create();
+        AllocateSurfaceTexture(temp_tex.handle, GetFormatTuple(color_surface->pixel_format),
+                               color_surface->GetScaledWidth(), color_surface->GetScaledHeight());
+        glCopyImageSubData(color_surface->texture.handle, GL_TEXTURE_2D, 0, 0, 0, 0,
+                           temp_tex.handle, GL_TEXTURE_2D, 0, 0, 0, 0, color_surface->GetScaledWidth(),
+                           color_surface->GetScaledHeight(), 1);
+        for (auto& unit : state.texture_units) {
+            if (unit.texture_2d == color_surface->texture.handle)
+                unit.texture_2d = temp_tex.handle;
+        }
+    }
+
     // Sync and bind the shader
     if (shader_dirty) {
         SetShader();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -233,7 +233,7 @@ static constexpr std::array<void (*)(u32, u32, u8*, PAddr, PAddr, PAddr), 18> gl
 };
 
 // Allocate an uninitialized texture of appropriate size and format for the surface
-static void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tuple, u32 width,
+void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tuple, u32 width,
                                    u32 height) {
     OpenGLState cur_state = OpenGLState::GetCurState();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -354,4 +354,7 @@ public:
     std::unique_ptr<FormatReinterpreterOpenGL> format_reinterpreter;
     std::unique_ptr<TextureDownloaderES> texture_downloader_es;
 };
+
+void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tuple, u32 width,
+                            u32 height);
 } // namespace OpenGL


### PR DESCRIPTION
The games are trying to sample and draw to the same surface at the same time, so we can just create duplicate image to use for sampling. I didn't notice any significant effect on performance.