### PR TITLE
Version name

### DIFF
--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -33,6 +33,7 @@ android {
         minSdkVersion 26
         targetSdkVersion 28
         versionCode autoVersion
+        versionName getVersion()
         ndk.abiFilters abiFilter
     }
 
@@ -121,4 +122,18 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
 
     implementation 'com.android.billingclient:billing:2.2.0'
+}
+
+def getVersion() {
+    def versionName = '0.0'
+
+    try {
+        versionName = 'git describe --always --long'.execute([], project.rootDir).text
+                .trim()
+                .replaceAll(/(-0)?-[^-]+$/, "")
+    } catch (Exception e) {
+        logger.error('Cannot find git, defaulting to dummy version number')
+    }
+
+    return versionName
 }


### PR DESCRIPTION
Current there is no version name set for the app, I feel like this might have been somehow lost during a merge.
So brought back the version name.

Edit: Fixes #15 
<details>
<summary>Screenshots</summary>

![Screenshot_20200528-202955](https://user-images.githubusercontent.com/26602104/83159132-4adac500-a123-11ea-9c9d-83abcd3efa81.jpg)

![Screenshot_20200528-203018](https://user-images.githubusercontent.com/26602104/83159302-72319200-a123-11ea-8622-4ea7b5ea47b9.jpg)
</details>