### PR TITLE
Fix the N3DS controls

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
@@ -514,6 +514,8 @@ public final class NativeLibrary {
         public static final int TRIGGER_L = 773;
         public static final int TRIGGER_R = 774;
         public static final int DPAD = 780;
+        public static final int BUTTON_DEBUG = 781;
+        public static final int BUTTON_GPIO14 = 782;
     }
 
     /**

--- a/src/android/app/src/main/jni/button_manager.cpp
+++ b/src/android/app/src/main/jni/button_manager.cpp
@@ -61,14 +61,15 @@ public:
 
     bool ChangeButtonStatus(int button_id, bool pressed) {
         std::lock_guard<std::mutex> guard(mutex);
+        bool button_found = false;
         for (const KeyButtonPair& pair : list) {
             if (pair.button_id == button_id) {
                 pair.key_button->status.store(pressed);
-                return true;
+                button_found = true;
             }
         }
         // If we don't find the button don't consume the button press event
-        return false;
+        return button_found;
     }
 
     void ChangeAllButtonStatus(bool pressed) {
@@ -132,14 +133,15 @@ public:
 
     bool ChangeAxisValue(int axis_id, float axis) {
         std::lock_guard<std::mutex> guard(mutex);
+        bool button_found = false;
         for (const AnalogButtonPair& pair : list) {
             if (pair.axis_id == axis_id) {
                 pair.key_button->axis_val.store(axis);
-                return true;
+                button_found = true;
             }
         }
         // If we don't find the button don't consume the button press event
-        return false;
+        return button_found;
     }
 
 private:
@@ -190,14 +192,15 @@ public:
 
     bool ChangeJoystickStatus(int analog_id, float x, float y) {
         std::lock_guard<std::mutex> guard(mutex);
+        bool button_found = false;
         for (const AnalogPair& pair : list) {
             if (pair.analog_id == analog_id) {
                 pair.key_button->x_axis.store(x);
                 pair.key_button->y_axis.store(y);
-                return true;
+                button_found = true;
             }
         }
-        return false;
+        return button_found;
     }
 
 private:

--- a/src/android/app/src/main/jni/button_manager.h
+++ b/src/android/app/src/main/jni/button_manager.h
@@ -38,6 +38,8 @@ enum ButtonType {
     N3DS_STICK_C_RIGHT = 772,
     N3DS_TRIGGER_L = 773,
     N3DS_TRIGGER_R = 774,
+    N3DS_BUTTON_DEBUG = 781,
+    N3DS_BUTTON_GPIO14 = 782
 };
 
 class ButtonList;

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -55,6 +55,7 @@ static const std::array<int, Settings::NativeButton::NumButtons> default_buttons
     InputManager::N3DS_BUTTON_Y,  InputManager::N3DS_DPAD_UP,      InputManager::N3DS_DPAD_DOWN,
     InputManager::N3DS_DPAD_LEFT, InputManager::N3DS_DPAD_RIGHT,   InputManager::N3DS_TRIGGER_L,
     InputManager::N3DS_TRIGGER_R, InputManager::N3DS_BUTTON_START, InputManager::N3DS_BUTTON_SELECT,
+    InputManager::N3DS_BUTTON_DEBUG, InputManager::N3DS_BUTTON_GPIO14,
     InputManager::N3DS_BUTTON_ZL, InputManager::N3DS_BUTTON_ZR,    InputManager::N3DS_BUTTON_HOME,
 };
 


### PR DESCRIPTION
This was a doozy to track down.

This fixes two issues that prevented N3DS controls from working in certain situations.

1. default_buttons in config.cpp was missing the Debug and GPIO14 buttons, meaning ZL got mapped to Home and ZR got mapped to nothing
This adds them to the array.
(Idk how these "7XX" numbers were picked, please give feedback)

2. button_manager.cpp would return as soon as a button matching the button_id/axis_id/analog_id was found
However, both IR_RST and ExtraHID create ZL and ZR button devices (I believe this is ultimately a result of intended behavior to allow platforms to map the same key to different actions)
This means the entire array of mappings must be searched.