### PR TITLE
android : InputOverlayDrawableDpad.java: Initialize mTrackId to -1

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableDpad.java
@@ -69,6 +69,8 @@ public final class InputOverlayDrawableDpad {
         mButtonType[1] = buttonDown;
         mButtonType[2] = buttonLeft;
         mButtonType[3] = buttonRight;
+
+        mTrackId = -1;
     }
 
     public void draw(Canvas canvas) {


### PR DESCRIPTION
Fixes an issue where the d-pad gets activated when touching anywhere on the screen right after rotation. 