### PR TITLE
Shield TV driver bug workaround

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -622,13 +622,13 @@ static void WriteTevStage(std::string& out, const PicaFSConfig& config, unsigned
     if (!IsPassThroughTevStage(stage)) {
         const std::string index_name = std::to_string(index);
 
-        out += fmt::format("vec3 color_results_{}[3] = vec3[3](", index_name);
+        out += fmt::format("vec3 color_results_{}_1 = ", index_name);
         AppendColorModifier(out, config, stage.color_modifier1, stage.color_source1, index_name);
-        out += ", ";
+        out += fmt::format(";\nvec3 color_results_{}_2 = ", index_name);
         AppendColorModifier(out, config, stage.color_modifier2, stage.color_source2, index_name);
-        out += ", ";
+        out += fmt::format(";\nvec3 color_results_{}_3 = ", index_name);
         AppendColorModifier(out, config, stage.color_modifier3, stage.color_source3, index_name);
-        out += ");\n";
+        out += fmt::format(";\nvec3 color_results_{}[3] = vec3[3](color_results_{}_1, color_results_{}_2, color_results_{}_3);\n", index_name, index_name, index_name, index_name);
 
         // Round the output of each TEV stage to maintain the PICA's 8 bits of precision
         out += fmt::format("vec3 color_output_{} = byteround(", index_name);


### PR DESCRIPTION
This works around an apparent driver bug on the Shield TV where it seems unable to construct an array of vec3's directly from the results of textureLod calls.

This is the 2nd of 3 PR's needed to make Citra work on the Nvidia Shield TV
The 1st required PR is #107 