### PR TITLE
Disable deptch stencil shader in texture_downloader_es for now

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -705,7 +705,7 @@ void CachedSurface::DumpTexture(GLuint target_tex, u64 tex_hash) {
         */
         // if the backend isn't OpenGL ES, this won't be initialized yet
         if (!owner.texture_downloader_es)
-            owner.texture_downloader_es = std::make_unique<TextureDownloaderES>();
+            owner.texture_downloader_es = std::make_unique<TextureDownloaderES>(false);
         owner.texture_downloader_es->GetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                                                  height, width, &decoded_texture[0]);
         state.texture_units[0].texture_2d = old_texture;
@@ -1020,7 +1020,7 @@ RasterizerCacheOpenGL::RasterizerCacheOpenGL() {
                                                          resolution_scale_factor);
     format_reinterpreter = std::make_unique<FormatReinterpreterOpenGL>();
     if (GLES)
-        texture_downloader_es = std::make_unique<TextureDownloaderES>();
+        texture_downloader_es = std::make_unique<TextureDownloaderES>(false);
 
     read_framebuffer.Create();
     draw_framebuffer.Create();

--- a/src/video_core/renderer_opengl/texture_downloader_es.cpp
+++ b/src/video_core/renderer_opengl/texture_downloader_es.cpp
@@ -88,7 +88,7 @@ void TextureDownloaderES::Test() {
     cur_state.Apply();
 }
 
-TextureDownloaderES::TextureDownloaderES() {
+TextureDownloaderES::TextureDownloaderES(bool enable_depth_stencil) {
     vao.Create();
     read_fbo_generic.Create();
 
@@ -101,7 +101,13 @@ TextureDownloaderES::TextureDownloaderES() {
         converter.program.Create(depth_to_color_vert.data(), frag.data());
         converter.lod_location = glGetUniformLocation(converter.program.handle, "lod");
     };
-    init_program(d24s8_r32ui_conversion_shader, ds_to_color_frag);
+
+    // xperia64: The depth stencil shader currently uses a GLES extension that is not supported across all devices
+    // Reportedly broken on Tegra devices and the Nexus 6P, so enabling it can be toggled
+    if(enable_depth_stencil) {
+        init_program(d24s8_r32ui_conversion_shader, ds_to_color_frag);
+    }
+
     init_program(d24_r32ui_conversion_shader, depth_to_color_frag);
     init_program(d16_r16_conversion_shader, R"(
 out highp float color;

--- a/src/video_core/renderer_opengl/texture_downloader_es.h
+++ b/src/video_core/renderer_opengl/texture_downloader_es.h
@@ -28,7 +28,7 @@ class TextureDownloaderES {
                                GLint width);
 
 public:
-    TextureDownloaderES();
+    TextureDownloaderES(bool enable_depth_stencil);
 
     void GetTexImage(GLenum target, GLuint level, GLenum format, const GLenum type, GLint height,
                      GLint width, void* pixels);


### PR DESCRIPTION
The depth stencil shader used by ds_to_color.frag currently requires the "GL_ARM_shader_framebuffer_fetch_depth_stencil" which is not supported on Tegra devices at the moment, and reportedly the Nexus 6P too.

As per the conversation with @BreadFish64, this has been disabled by adding a parameter to the constructor to allow disabling depth stencil support by the caller.

This is the 3rd PR required to fix the Shield TV.