### PR TITLE
Touchscreen fix v2

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
@@ -96,8 +96,9 @@ public final class NativeLibrary {
      * @param x_axis  The value of the x-axis.
      * @param y_axis  The value of the y-axis
      * @param pressed To identify if the touch held down or released.
+     * @return true if the pointer is within the touchscreen
      */
-    public static native void onTouchEvent(float x_axis, float y_axis, boolean pressed);
+    public static native boolean onTouchEvent(float x_axis, float y_axis, boolean pressed);
 
     /**
      * Handles touch movement.

--- a/src/android/app/src/main/jni/emu_window/emu_window.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window.cpp
@@ -81,12 +81,13 @@ void EmuWindow_Android::OnSurfaceChanged(ANativeWindow* surface) {
     render_window = surface;
 }
 
-void EmuWindow_Android::OnTouchEvent(int x, int y, bool pressed) {
+bool EmuWindow_Android::OnTouchEvent(int x, int y, bool pressed) {
     if (pressed) {
-        TouchPressed((unsigned)std::max(x, 0), (unsigned)std::max(y, 0));
-    } else {
-        TouchReleased();
+        return TouchPressed((unsigned)std::max(x, 0), (unsigned)std::max(y, 0));
     }
+
+    TouchReleased();
+    return true;
 }
 
 void EmuWindow_Android::OnTouchMoved(int x, int y) {

--- a/src/android/app/src/main/jni/emu_window/emu_window.h
+++ b/src/android/app/src/main/jni/emu_window/emu_window.h
@@ -42,7 +42,7 @@ public:
     void OnSurfaceChanged(ANativeWindow* surface);
 
     /// Handles touch event that occur.(Touched or released)
-    void OnTouchEvent(int x, int y, bool pressed);
+    bool OnTouchEvent(int x, int y, bool pressed);
 
     /// Handles movement of touch pointer
     void OnTouchMoved(int x, int y);

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -343,10 +343,10 @@ jboolean Java_org_citra_citra_1emu_NativeLibrary_onGamePadAxisEvent(JNIEnv* env,
         InputManager::ButtonHandler()->AnalogButtonEvent(axis_id, axis_val));
 }
 
-void Java_org_citra_citra_1emu_NativeLibrary_onTouchEvent(JNIEnv* env,
+jboolean Java_org_citra_citra_1emu_NativeLibrary_onTouchEvent(JNIEnv* env,
                                                           [[maybe_unused]] jclass clazz, jfloat x,
                                                           jfloat y, jboolean pressed) {
-    window->OnTouchEvent((int)x, (int)y, (bool)pressed);
+    return static_cast<jboolean>(window->OnTouchEvent(static_cast<int>(x + 0.5), static_cast<int>(y + 0.5), pressed));
 }
 
 void Java_org_citra_citra_1emu_NativeLibrary_onTouchMoved(JNIEnv* env,

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -32,7 +32,7 @@ JNIEXPORT jboolean JNICALL Java_org_citra_citra_1emu_NativeLibrary_onGamePadMove
 JNIEXPORT jboolean JNICALL Java_org_citra_citra_1emu_NativeLibrary_onGamePadAxisEvent(
     JNIEnv* env, jclass clazz, jstring j_device, jint axis_id, jfloat axis_val);
 
-JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_onTouchEvent(JNIEnv* env,
+JNIEXPORT jboolean JNICALL Java_org_citra_citra_1emu_NativeLibrary_onTouchEvent(JNIEnv* env,
                                                                             jclass clazz, jfloat x,
                                                                             jfloat y,
                                                                             jboolean pressed);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -98,9 +98,9 @@ std::tuple<unsigned, unsigned> EmuWindow::ClipToTouchScreen(unsigned new_x, unsi
     return std::make_tuple(new_x, new_y);
 }
 
-void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
+bool EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
     if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y))
-        return;
+        return false;
 
     if (Settings::values.render_3d == Settings::StereoRenderOption::SideBySide &&
         framebuffer_x >= framebuffer_layout.width / 2)
@@ -126,6 +126,7 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
     }
 
     touch_state->touch_pressed = true;
+    return true;
 }
 
 void EmuWindow::TouchReleased() {

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -115,8 +115,9 @@ public:
      * Signal that a touch pressed event has occurred (e.g. mouse click pressed)
      * @param framebuffer_x Framebuffer x-coordinate that was pressed
      * @param framebuffer_y Framebuffer y-coordinate that was pressed
+     * @returns True if the coordinates are within the touchpad, otherwise false
      */
-    void TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y);
+    bool TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y);
 
     /// Signal that a touch released event has occurred (e.g. mouse click released)
     void TouchReleased();


### PR DESCRIPTION
Add proper multitouch tracking so buttons and touchscreen can be interacted at the same time.
this should fix #87 and maybe some other related issues.

There are a couple of problems remaining-
1. Buttons overlayed on the touchscreen, this behaviour is unchanged from previous versions and the touch triggers both the button and wherever the 3DS screen is touched
2. The latest touch pointer is given priority and tracked when it 'presses' the 3DS touchscreen, not sure if this is the best thing to do, need some feedback on this.