### PR TITLE
Clamp the circle pad more correctly

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/overlay/InputOverlayDrawableJoystick.java
@@ -139,9 +139,16 @@ public final class InputOverlayDrawableJoystick {
                 maxY -= getVirtBounds().centerY();
                 final float AxisX = touchX / maxX;
                 final float AxisY = touchY / maxY;
-                axises[0] = AxisX;
-                axises[1] = AxisY;
 
+                // Clamp the circle pad input to a circle
+                final float angle = (float) Math.atan2(AxisY, AxisX);
+                float radius = (float) Math.sqrt(AxisX * AxisX + AxisY * AxisY);
+                if(radius > 1.0f)
+                {
+                    radius = 1.0f;
+                }
+                axises[0] = ((float)Math.cos(angle) * radius);
+                axises[1] = ((float)Math.sin(angle) * radius);
                 SetInnerBounds();
             }
         }

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -332,6 +332,14 @@ jboolean Java_org_citra_citra_1emu_NativeLibrary_onGamePadMoveEvent(JNIEnv* env,
     // Citra uses an inverted y axis sent by the frontend
     x = std::clamp(x, -1.f, 1.f);
     y = std::clamp(-y, -1.f, 1.f);
+
+    // Clamp the input to a circle (while touch input is already clamped in the frontend, gamepad is unknown)
+    float r = x * x + y * y;
+    if (r > 1.0f) {
+        r = std::sqrt(r);
+        x /= r;
+        y /= r;
+    }
     return static_cast<jboolean>(InputManager::AnalogHandler()->MoveJoystick(axis, x, y));
 }
 


### PR DESCRIPTION
This makes the touch screen circle pad actually bounded by a circle rather than a box, and ensures all inputs passed to the emulator actually meet the assumptions of the HID service, so gamepad input is clamped correctly too.