### PR TITLE
AndroidManifest: Increase the maximum aspect ratio

### DIFF
--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:isGame="true"
         android:banner="@mipmap/ic_launcher">
 
-        <meta-data android:name="android.max_aspect" android:value="2.1" />
+        <meta-data android:name="android.max_aspect" android:value="2.4" />
 
         <activity
             android:name="org.citra.citra_emu.ui.main.MainActivity"

--- a/src/android/app/src/main/AndroidManifest.xml
+++ b/src/android/app/src/main/AndroidManifest.xml
@@ -30,8 +30,6 @@
         android:isGame="true"
         android:banner="@mipmap/ic_launcher">
 
-        <meta-data android:name="android.max_aspect" android:value="2.4" />
-
         <activity
             android:name="org.citra.citra_emu.ui.main.MainActivity"
             android:theme="@style/CitraBase"


### PR DESCRIPTION
This should help display the app on the whole screen on 21:9 devices like the Xperia Z5.

Hopefully fixes https://github.com/citra-emu/citra-android/issues/141.

