### PR TITLE
Wait on present_queue instead of free_queue

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -120,7 +120,7 @@ public:
         // If theres no free frames, we will reuse the oldest render frame
         if (free_queue.empty()) {
             // wait for new entries in the present_queue
-            free_cv.wait_for(lock, elapsed, [this] { return !free_queue.empty(); });
+            free_cv.wait_for(lock, elapsed, [this] { return !present_queue.empty(); });
             if (free_queue.empty()) {
                 auto frame = present_queue.back();
                 present_queue.pop_back();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -121,11 +121,9 @@ public:
         if (free_queue.empty()) {
             // wait for new entries in the present_queue
             free_cv.wait_for(lock, elapsed, [this] { return !present_queue.empty(); });
-            if (free_queue.empty()) {
-                auto frame = present_queue.back();
-                present_queue.pop_back();
-                return frame;
-            }
+            auto frame = present_queue.back();
+            present_queue.pop_back();
+            return frame;
         }
 
         Frontend::Frame* frame = free_queue.front();


### PR DESCRIPTION
Fixes #144.

Waiting here on free_queue causes emulation to be limited to 100%. However, I don't know if this is the correct placement for this, so should it be moved to `TryGetPresentFrame()` @weihuoya? The issue is fixed on both cases.