### PR TITLE
Add savestates feature

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
@@ -16,6 +16,7 @@ import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 
@@ -25,6 +26,7 @@ import org.citra.citra_emu.utils.Log;
 import org.citra.citra_emu.utils.PermissionsHandler;
 
 import java.lang.ref.WeakReference;
+import java.util.Date;
 
 import static android.Manifest.permission.CAMERA;
 import static android.Manifest.permission.RECORD_AUDIO;
@@ -486,6 +488,19 @@ public final class NativeLibrary {
     public static native void RemoveAmiibo();
 
     public static native void InstallCIAS(String[] path);
+
+    public static final int SAVESTATE_SLOT_COUNT = 10;
+
+    public static final class SavestateInfo {
+        public int slot;
+        public Date time;
+    }
+
+    @Nullable
+    public static native SavestateInfo[] GetSavestateInfo();
+
+    public static native void SaveState(int slot);
+    public static native void LoadState(int slot);
 
     /**
      * Button type for use in onTouchEvent

--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
@@ -16,6 +16,7 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.SubMenu;
 import android.view.View;
+import android.widget.CheckBox;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
@@ -26,6 +27,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.fragment.app.FragmentActivity;
 
+import org.citra.citra_emu.CitraApplication;
 import org.citra.citra_emu.NativeLibrary;
 import org.citra.citra_emu.R;
 import org.citra.citra_emu.features.settings.model.view.InputBindingSetting;
@@ -304,6 +306,26 @@ public final class EmulationActivity extends AppCompatActivity {
         return true;
     }
 
+    private void DisplaySavestateWarning() {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(CitraApplication.getAppContext());
+        if (preferences.getBoolean("savestateWarningShown", false)) {
+            return;
+        }
+
+        LayoutInflater inflater = mEmulationFragment.requireActivity().getLayoutInflater();
+        View view = inflater.inflate(R.layout.dialog_checkbox, null);
+        CheckBox checkBox = view.findViewById(R.id.checkBox);
+
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.savestate_warning_title)
+                .setMessage(R.string.savestate_warning_message)
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    preferences.edit().putBoolean("savestateWarningShown", checkBox.isChecked()).apply();
+                })
+                .show();
+    }
+
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
@@ -327,6 +349,7 @@ public final class EmulationActivity extends AppCompatActivity {
             final int slot = i + 1;
             final String text = getString(R.string.emulation_empty_state_slot, slot);
             saveStateMenu.add(text).setEnabled(true).setOnMenuItemClickListener((item) -> {
+                DisplaySavestateWarning();
                 NativeLibrary.SaveState(slot);
                 return true;
             });

--- a/src/android/app/src/main/jni/emu_window/emu_window.cpp
+++ b/src/android/app/src/main/jni/emu_window/emu_window.cpp
@@ -246,7 +246,7 @@ void EmuWindow_Android::TryPresenting() {
         }
     }
     eglSwapInterval(egl_display, Settings::values.use_vsync_new ? 1 : 0);
-    if (VideoCore::g_renderer->TryPresent()) {
+    if (VideoCore::g_renderer && VideoCore::g_renderer->TryPresent()) {
         eglSwapBuffers(egl_display, egl_surface);
     }
 }

--- a/src/android/app/src/main/jni/id_cache.cpp
+++ b/src/android/app/src/main/jni/id_cache.cpp
@@ -19,7 +19,9 @@ static constexpr jint JNI_VERSION = JNI_VERSION_1_6;
 static JavaVM* s_java_vm;
 
 static jclass s_native_library_class;
+static jclass s_core_error_class;
 static jclass s_savestate_info_class;
+static jmethodID s_on_core_error;
 static jmethodID s_display_alert_msg;
 static jmethodID s_display_alert_prompt;
 static jmethodID s_alert_prompt_button;
@@ -54,8 +56,16 @@ jclass GetNativeLibraryClass() {
     return s_native_library_class;
 }
 
+jclass GetCoreErrorClass() {
+    return s_core_error_class;
+}
+
 jclass GetSavestateInfoClass() {
     return s_savestate_info_class;
+}
+
+jmethodID GetOnCoreError() {
+    return s_on_core_error;
 }
 
 jmethodID GetDisplayAlertMsg() {
@@ -118,6 +128,11 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     s_native_library_class = reinterpret_cast<jclass>(env->NewGlobalRef(native_library_class));
     s_savestate_info_class = reinterpret_cast<jclass>(
         env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$SavestateInfo")));
+    s_core_error_class = reinterpret_cast<jclass>(
+        env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$CoreError")));
+    s_on_core_error = env->GetStaticMethodID(
+        s_native_library_class, "OnCoreError",
+        "(Lorg/citra/citra_emu/NativeLibrary$CoreError;Ljava/lang/String;)Z");
     s_display_alert_msg = env->GetStaticMethodID(s_native_library_class, "displayAlertMsg",
                                                  "(Ljava/lang/String;Ljava/lang/String;Z)Z");
     s_display_alert_prompt =
@@ -150,6 +165,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
 
     env->DeleteGlobalRef(s_native_library_class);
     env->DeleteGlobalRef(s_savestate_info_class);
+    env->DeleteGlobalRef(s_core_error_class);
     MiiSelector::CleanupJNI(env);
     SoftwareKeyboard::CleanupJNI(env);
     Camera::StillImage::CleanupJNI(env);

--- a/src/android/app/src/main/jni/id_cache.cpp
+++ b/src/android/app/src/main/jni/id_cache.cpp
@@ -19,6 +19,7 @@ static constexpr jint JNI_VERSION = JNI_VERSION_1_6;
 static JavaVM* s_java_vm;
 
 static jclass s_native_library_class;
+static jclass s_savestate_info_class;
 static jmethodID s_display_alert_msg;
 static jmethodID s_display_alert_prompt;
 static jmethodID s_alert_prompt_button;
@@ -51,6 +52,10 @@ JNIEnv* GetEnvForThread() {
 
 jclass GetNativeLibraryClass() {
     return s_native_library_class;
+}
+
+jclass GetSavestateInfoClass() {
+    return s_savestate_info_class;
 }
 
 jmethodID GetDisplayAlertMsg() {
@@ -111,6 +116,8 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     // Initialize Java methods
     const jclass native_library_class = env->FindClass("org/citra/citra_emu/NativeLibrary");
     s_native_library_class = reinterpret_cast<jclass>(env->NewGlobalRef(native_library_class));
+    s_savestate_info_class = reinterpret_cast<jclass>(
+        env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$SavestateInfo")));
     s_display_alert_msg = env->GetStaticMethodID(s_native_library_class, "displayAlertMsg",
                                                  "(Ljava/lang/String;Ljava/lang/String;Z)Z");
     s_display_alert_prompt =
@@ -142,6 +149,7 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
     }
 
     env->DeleteGlobalRef(s_native_library_class);
+    env->DeleteGlobalRef(s_savestate_info_class);
     MiiSelector::CleanupJNI(env);
     SoftwareKeyboard::CleanupJNI(env);
     Camera::StillImage::CleanupJNI(env);

--- a/src/android/app/src/main/jni/id_cache.h
+++ b/src/android/app/src/main/jni/id_cache.h
@@ -12,6 +12,7 @@ namespace IDCache {
 
 JNIEnv* GetEnvForThread();
 jclass GetNativeLibraryClass();
+jclass GetSavestateInfoClass();
 jmethodID GetDisplayAlertMsg();
 jmethodID GetDisplayAlertPrompt();
 jmethodID GetAlertPromptButton();

--- a/src/android/app/src/main/jni/id_cache.h
+++ b/src/android/app/src/main/jni/id_cache.h
@@ -12,7 +12,9 @@ namespace IDCache {
 
 JNIEnv* GetEnvForThread();
 jclass GetNativeLibraryClass();
+jclass GetCoreErrorClass();
 jclass GetSavestateInfoClass();
+jmethodID GetOnCoreError();
 jmethodID GetDisplayAlertMsg();
 jmethodID GetDisplayAlertPrompt();
 jmethodID GetAlertPromptButton();

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -688,7 +688,6 @@ jobjectArray Java_org_citra_citra_1emu_NativeLibrary_GetSavestateInfo(
 
         env->SetObjectArrayElement(array, i, object);
     }
-    LOG_CRITICAL(Frontend, "Called");
     return array;
 }
 

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -33,9 +33,9 @@ JNIEXPORT jboolean JNICALL Java_org_citra_citra_1emu_NativeLibrary_onGamePadAxis
     JNIEnv* env, jclass clazz, jstring j_device, jint axis_id, jfloat axis_val);
 
 JNIEXPORT jboolean JNICALL Java_org_citra_citra_1emu_NativeLibrary_onTouchEvent(JNIEnv* env,
-                                                                            jclass clazz, jfloat x,
-                                                                            jfloat y,
-                                                                            jboolean pressed);
+                                                                                jclass clazz,
+                                                                                jfloat x, jfloat y,
+                                                                                jboolean pressed);
 
 JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_onTouchMoved(JNIEnv* env,
                                                                             jclass clazz, jfloat x,
@@ -142,7 +142,18 @@ JNIEXPORT jboolean Java_org_citra_citra_1emu_NativeLibrary_LoadAmiibo(JNIEnv* en
 
 JNIEXPORT void Java_org_citra_citra_1emu_NativeLibrary_RemoveAmiibo(JNIEnv* env, jclass clazz);
 
-JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_InstallCIAS(JNIEnv* env, jclass clazz, jobjectArray path);
+JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_InstallCIAS(JNIEnv* env,
+                                                                           jclass clazz,
+                                                                           jobjectArray path);
+
+JNIEXPORT jobjectArray JNICALL
+Java_org_citra_citra_1emu_NativeLibrary_GetSavestateInfo(JNIEnv* env, jclass clazz);
+
+JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_SaveState(JNIEnv* env, jclass clazz,
+                                                                         jint slot);
+
+JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_LoadState(JNIEnv* env, jclass clazz,
+                                                                         jint slot);
 
 #ifdef __cplusplus
 }

--- a/src/android/app/src/main/res/layout/dialog_checkbox.xml
+++ b/src/android/app/src/main/res/layout/dialog_checkbox.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:paddingTop="5dp"
+    android:paddingLeft="20dp"
+    android:paddingRight="20dp"
+    android:paddingBottom="0dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <CheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/do_not_show_this_again" />
+</LinearLayout>

--- a/src/android/app/src/main/res/menu/menu_emulation.xml
+++ b/src/android/app/src/main/res/menu/menu_emulation.xml
@@ -4,6 +4,18 @@
     tools:context="org.citra.citra_emu.activities.EmulationActivity">
 
     <item
+        android:id="@+id/menu_emulation_save_state"
+        android:title="@string/emulation_save_state">
+        <menu/>
+    </item>
+
+    <item
+        android:id="@+id/menu_emulation_load_state"
+        android:title="@string/emulation_load_state">
+        <menu/>
+    </item>
+
+    <item
         android:id="@+id/menu_emulation_configure_controls"
         android:title="@string/emulation_configure_controls">
         <menu>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -181,6 +181,10 @@
     <string name="select_dir">Select This Directory</string>
     <string name="empty_gamelist">No files were found or no game directory has been selected yet.</string>
 
+    <string name="do_not_show_this_again">Do not show this again</string>
+    <string name="savestate_warning_title">Savestates</string>
+    <string name="savestate_warning_message">Warning: Savestates are NOT a replacement for in-game saves, and are not meant to be reliable.\n\nUse at your own risk!</string>
+
     <!-- Software Keyboard -->
     <string name="software_keyboard">Software Keyboard</string>
     <string name="i_forgot">I Forgot</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -201,4 +201,14 @@
     <!-- Microphone -->
     <string name="microphone">Microphone</string>
     <string name="microphone_permission_needed">Citra needs to access your microphone to emulate the 3DS\'s microphone.\n\nAlternatively, you can also change \"Audio Input Device\" in Audio Settings.</string>
+
+    <!-- Core Errors -->
+    <string name="abort_button">Abort</string>
+    <string name="continue_button">Continue</string>
+    <string name="system_archive_not_found">System Archive Not Found</string>
+    <string name="system_archive_not_found_message">%s is missing. Please dump your system archives.\nContinuing emulation may result in crashes and bugs.</string>
+    <string name="system_archive_general">A system archive</string>
+    <string name="save_load_error">Save/Load Error</string>
+    <string name="fatal_error">Fatal Error</string>
+    <string name="fatal_error_message">A fatal error occurred. Check the log for details.\nContinuing emulation may result in crashes and bugs.</string>
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -143,6 +143,10 @@
     <string name="loader_error_invalid_format">Invalid ROM format</string>
 
     <!-- Emulation Menu -->
+    <string name="emulation_save_state">Save State</string>
+    <string name="emulation_load_state">Load State</string>
+    <string name="emulation_empty_state_slot">Slot %1$d</string>
+    <string name="emulation_occupied_state_slot">Slot %1$d - %2$tF %2$tR</string>
     <string name="emulation_show_fps">Show FPS</string>
     <string name="emulation_configure_controls">Configure Controls</string>
     <string name="emulation_edit_layout">Edit Layout</string>

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -13,6 +13,8 @@ GPUBackend::GPUBackend(VideoCore::RendererBase& renderer) : renderer{renderer} {
 
 GPUBackend::~GPUBackend() = default;
 
+void GPUBackend::WaitForProcessing() {}
+
 GPUSerial::GPUSerial(Core::System& system, VideoCore::RendererBase& renderer)
     : GPUBackend(renderer), system{system} {}
 
@@ -81,6 +83,10 @@ void GPUParallel::FlushAndInvalidateRegion(VAddr addr, u64 size) {
 
 void GPUParallel::InvalidateRegion(VAddr addr, u64 size) {
     gpu_thread.InvalidateRegion(addr, size);
+}
+
+void GPUParallel::WaitForProcessing() {
+    gpu_thread.WaitForProcessing();
 }
 
 } // namespace VideoCore

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -29,6 +29,7 @@ public:
     virtual void FlushRegion(VAddr addr, u64 size) = 0;
     virtual void FlushAndInvalidateRegion(VAddr addr, u64 size) = 0;
     virtual void InvalidateRegion(VAddr addr, u64 size) = 0;
+    virtual void WaitForProcessing();
 
 protected:
     VideoCore::RendererBase& renderer;
@@ -65,6 +66,7 @@ public:
     void FlushRegion(VAddr addr, u64 size) override;
     void FlushAndInvalidateRegion(VAddr addr, u64 size) override;
     void InvalidateRegion(VAddr addr, u64 size) override;
+    void WaitForProcessing() override;
 
 private:
     GPUThread::ThreadManager gpu_thread;

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -169,9 +169,14 @@ struct SynchState final {
         // commands_condition.wait(lock, [this] { return !queue.Empty(); });
     }
 
+    void WaitForProcessing() {
+        while (!queue.Empty() && is_running)
+            ;
+    }
+
     using CommandQueue = Common::SPSCQueue<CommandDataContainer>;
     CommandQueue queue;
-    u64 last_fence{};
+    std::atomic<u64> last_fence{};
     std::atomic<u64> signaled_fence{};
 };
 
@@ -194,6 +199,8 @@ public:
     void FlushAndInvalidateRegion(VAddr addr, u64 size);
 
     void InvalidateRegion(VAddr addr, u64 size);
+
+    void WaitForProcessing();
 
 private:
     void Synchronize(u64 fence, Settings::GpuTimingMode mode);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1193,6 +1193,10 @@ VideoCore::ResultStatus RendererOpenGL::Init() {
     }
 #endif
 
+    if (Settings::values.use_asynchronous_gpu_emulation) {
+        render_window.MakeCurrent();
+    }
+
     const char* gl_version{reinterpret_cast<char const*>(glGetString(GL_VERSION))};
     const char* gpu_vendor{reinterpret_cast<char const*>(glGetString(GL_VENDOR))};
     const char* gpu_model{reinterpret_cast<char const*>(glGetString(GL_RENDERER))};

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -104,6 +104,7 @@ u16 GetResolutionScaleFactor() {
 
 template <class Archive>
 void serialize(Archive& ar, const unsigned int) {
+    g_gpu->WaitForProcessing();
     ar& Pica::g_state;
 }
 


### PR DESCRIPTION
This adds the savestates feature to Citra Android.

The first commit features several changes to make savestates actually work with the android frontend and async GPU. The second commit adds the frontend for savestates (for now, this is a simple menu). The third commit adds code to report and handle core errors (including save/load errors), similar to what we do in the Qt frontend.

Screenshots:
![Screenshot_20200814_235346](https://user-images.githubusercontent.com/21307832/90269884-ed395780-de8b-11ea-8a5b-e7790ede9c19.jpg) ![Screenshot_20200815_001001](https://user-images.githubusercontent.com/21307832/90269886-ee6a8480-de8b-11ea-8dfb-003070a0ce46.jpg)

Notes:
1. The menu is not shown for applications without a Title ID, like 3DSX homebrews.
1. Java code in this PR is not properly formatted because I'm not sure what style we are following (it's not clang format)
1. ~~We need to inform users that savestates are not meant to be reliable. There are several possible ways of doing this. We can show a popup when `Save State` is used for the first time. (Or we can be clever and show a popup when we detect a potential abuse; e.g. a savestate that has been saved and loaded multiple times) We can also do what Dolphin does and hide savestates by default so you have to manually enable it.~~ (implemented)
1. The emulation menu is rather crowded now, and it's not the most well-organized menu for sure. I have a proposal for reorganizing it, but it won't be in this PR.

Known issues to be fixed:
1. ~~On my phone, the app randomly segfaults when exiting a game. I tried master and it crashes too, so likely this code is not at fault. Still, please kindly test everything and report any bugs you notice.~~ (apparently not happening for others)
1. ~~Changing orientation when a core error dialog is displayed freezes the game (as usual lol)~~ (fixed)