### PR TITLE
Fix SettingsActivity back stack behavior after stop+start

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivity.java
@@ -97,13 +97,11 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     }
 
     @Override
-    public void onBackPressed() {
-        mPresenter.onBackPressed();
-    }
-
-
-    @Override
     public void showSettingsFragment(String menuTag, boolean addToStack, String gameID) {
+        if (!addToStack && getFragment() != null) {
+            return;
+        }
+
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
         if (addToStack) {
@@ -116,7 +114,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
             }
 
             transaction.addToBackStack(null);
-            mPresenter.addToStack();
         }
         transaction.replace(R.id.frame_content, SettingsFragment.newInstance(menuTag, gameID), FRAGMENT_TAG);
 
@@ -205,11 +202,6 @@ public final class SettingsActivity extends AppCompatActivity implements Setting
     @Override
     public void showToastMessage(String message, boolean is_long) {
         Toast.makeText(this, message, is_long ? Toast.LENGTH_LONG : Toast.LENGTH_SHORT).show();
-    }
-
-    @Override
-    public void popBackStack() {
-        getSupportFragmentManager().popBackStackImmediate();
     }
 
     @Override

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityPresenter.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityPresenter.java
@@ -22,8 +22,6 @@ public final class SettingsActivityPresenter {
 
     private Settings mSettings = new Settings();
 
-    private int mStackCount;
-
     private boolean mShouldSave;
 
     private DirectoryStateReceiver directoryStateReceiver;
@@ -45,7 +43,6 @@ public final class SettingsActivityPresenter {
     }
 
     public void onStart() {
-        this.mStackCount = 0;
         prepareCitraDirectoriesIfNeeded();
     }
 
@@ -115,19 +112,6 @@ public final class SettingsActivityPresenter {
         ThemeUtil.applyTheme();
 
         NativeLibrary.ReloadSettings();
-    }
-
-    public void addToStack() {
-        mStackCount++;
-    }
-
-    public void onBackPressed() {
-        if (mStackCount > 0) {
-            mView.popBackStack();
-            mStackCount--;
-        } else {
-            mView.finish();
-        }
     }
 
     public void onSettingChanged() {

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityView.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivityView.java
@@ -56,11 +56,6 @@ public interface SettingsActivityView {
     void showToastMessage(String message, boolean is_long);
 
     /**
-     * Show the previous fragment.
-     */
-    void popBackStack();
-
-    /**
      * End the activity.
      */
     void finish();


### PR DESCRIPTION
Fixes the behavior where the settings activity would go back to the top-level menu after switching to a different app and back.

This is the same change as https://github.com/dolphin-emu/dolphin/pull/9009/commits/05e49b13ef5f28c0fe8705030bdd2fa975d02aff. I'm not sure if backporting changes from Dolphin is something you do often or not, but I saw that you had this problem that has been fixed in Dolphin and thought I might as well backport the fix :)