### PR TITLE
Add Disk shader cache 

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
@@ -39,9 +39,6 @@ public class DiskShaderCacheProgress {
     private static ProgressDialogFragment fragment;
 
     public static class ProgressDialogFragment extends DialogFragment {
-
-        private final Handler updateHandler = new Handler();
-
         ProgressBar progressBar;
         TextView progressText;
         AlertDialog dialog;
@@ -92,7 +89,7 @@ public class DiskShaderCacheProgress {
         }
 
         private void onUpdateProgress(String msg, int progress, int max) {
-            updateHandler.post(()->{
+            Objects.requireNonNull(getActivity()).runOnUiThread(() -> {
                 progressBar.setProgress(progress);
                 progressBar.setMax(max);
                 progressText.setText(String.format("%d/%d", progress, max));

--- a/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
@@ -1,3 +1,7 @@
+// Copyright 2021 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 package org.citra.citra_emu.disk_shader_cache;
 
 import android.app.Activity;

--- a/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
@@ -1,0 +1,136 @@
+package org.citra.citra_emu.disk_shader_cache;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.os.Handler;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ProgressBar;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
+
+import org.citra.citra_emu.CitraApplication;
+import org.citra.citra_emu.NativeLibrary;
+import org.citra.citra_emu.R;
+import org.citra.citra_emu.activities.EmulationActivity;
+
+import java.util.Objects;
+
+public class DiskShaderCacheProgress {
+
+    // Equivalent to VideoCore::LoadCallbackStage
+    public enum LoadCallbackStage {
+        Prepare,
+        Decompile,
+        Build,
+        Complete,
+    }
+
+    private static final Object finishLock = new Object();
+    private static ProgressDialogFragment fragment;
+
+    public static class ProgressDialogFragment extends DialogFragment {
+
+        private final Handler updateHandler = new Handler();
+
+        ProgressBar progressBar;
+        TextView progressText;
+        AlertDialog dialog;
+
+        static ProgressDialogFragment newInstance(String title, String message) {
+            ProgressDialogFragment frag = new ProgressDialogFragment();
+            Bundle args = new Bundle();
+            args.putString("title", title);
+            args.putString("message", message);
+            frag.setArguments(args);
+            return frag;
+        }
+
+        @NonNull
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            final Activity emulationActivity = Objects.requireNonNull(getActivity());
+
+            final String title = Objects.requireNonNull(Objects.requireNonNull(getArguments()).getString("title"));
+            final String message = Objects.requireNonNull(Objects.requireNonNull(getArguments()).getString("message"));
+
+            LayoutInflater inflater = LayoutInflater.from(emulationActivity);
+            View view = inflater.inflate(R.layout.dialog_progress_bar, null);
+
+            progressBar = view.findViewById(R.id.progress_bar);
+            progressText = view.findViewById(R.id.progress_text);
+            progressText.setText("");
+
+            setCancelable(false);
+            setRetainInstance(true);
+
+            AlertDialog.Builder builder = new AlertDialog.Builder(emulationActivity);
+            builder.setTitle(title);
+            builder.setMessage(message);
+            builder.setView(view);
+            builder.setNegativeButton(R.string.abort_button, (dialog, whichButton) -> {
+
+            });
+
+            dialog = builder.create();
+            dialog.create();
+
+            synchronized (finishLock) {
+                finishLock.notifyAll();
+            }
+
+            return dialog;
+        }
+
+        private void onUpdateProgress(LoadCallbackStage stage, int progress, int max) {
+            updateHandler.post(()->{
+                progressBar.setProgress(progress);
+                progressBar.setMax(max);
+                progressText.setText(String.format("%d/%d", progress, max));
+                if (stage == LoadCallbackStage.Build){
+                    dialog.setMessage("Building shaders");
+                }
+            });
+        }
+    }
+
+    private static void prepareDialog() {
+        NativeLibrary.sEmulationActivity.get().runOnUiThread(() -> {
+            final EmulationActivity emulationActivity = NativeLibrary.sEmulationActivity.get();
+            fragment = ProgressDialogFragment.newInstance("Loading...", "Preparing shaders");
+            fragment.show(emulationActivity.getSupportFragmentManager(), "diskShaders");
+        });
+
+        synchronized (finishLock) {
+            try {
+                finishLock.wait();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    public static void loadProgress(LoadCallbackStage stage, int progress, int max) {
+        switch (stage) {
+            case Prepare:
+                prepareDialog();
+                break;
+            case Decompile:
+            case Build:
+                fragment.onUpdateProgress(stage, progress, max);
+                break;
+            case Complete:
+                // Workaround for when dialog is dismissed when the app is in the background
+                fragment.dismissAllowingStateLoss();
+                break;
+        }
+    }
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
@@ -115,6 +115,7 @@ public class DiskShaderCacheProgress {
     public static void loadProgress(LoadCallbackStage stage, int progress, int max) {
         final EmulationActivity emulationActivity = NativeLibrary.sEmulationActivity.get();
         if (emulationActivity == null) {
+            Log.error("[DiskShaderCacheProgress] EmulationActivity not present");
             return;
         }
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress.java
@@ -93,11 +93,12 @@ public class DiskShaderCacheProgress {
 
         private void onUpdateProgress(LoadCallbackStage stage, int progress, int max) {
             updateHandler.post(()->{
+                final EmulationActivity emulationActivity = NativeLibrary.sEmulationActivity.get();
                 progressBar.setProgress(progress);
                 progressBar.setMax(max);
                 progressText.setText(String.format("%d/%d", progress, max));
                 if (stage == LoadCallbackStage.Build){
-                    dialog.setMessage("Building shaders");
+                    dialog.setMessage(emulationActivity.getString(R.string.disk_cache_building));
                 }
             });
         }
@@ -106,7 +107,7 @@ public class DiskShaderCacheProgress {
     private static void prepareDialog() {
         NativeLibrary.sEmulationActivity.get().runOnUiThread(() -> {
             final EmulationActivity emulationActivity = NativeLibrary.sEmulationActivity.get();
-            fragment = ProgressDialogFragment.newInstance("Loading...", "Preparing shaders");
+            fragment = ProgressDialogFragment.newInstance(emulationActivity.getString(R.string.disk_shaders_loading), emulationActivity.getString(R.string.disk_shaders_preparing));
             fragment.show(emulationActivity.getSupportFragmentManager(), "diskShaders");
         });
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.java
@@ -357,6 +357,7 @@ public final class SettingsFragmentPresenter {
         Setting shadersAccurateMul = rendererSection.getSetting(SettingsFile.KEY_SHADERS_ACCURATE_MUL);
         Setting render3dMode = rendererSection.getSetting(SettingsFile.KEY_RENDER_3D);
         Setting factor3d = rendererSection.getSetting(SettingsFile.KEY_FACTOR_3D);
+        Setting useDiskShaderCache = rendererSection.getSetting(SettingsFile.KEY_USE_DISK_SHADER_CACHE);
 
         SettingSection layoutSection = mSettings.getSection(Settings.SECTION_LAYOUT);
         Setting cardboardScreenSize = layoutSection.getSetting(SettingsFile.KEY_CARDBOARD_SCREEN_SIZE);
@@ -368,6 +369,7 @@ public final class SettingsFragmentPresenter {
         sl.add(new CheckBoxSetting(SettingsFile.KEY_FILTER_MODE, Settings.SECTION_RENDERER, R.string.linear_filtering, R.string.linear_filtering_description, true, filterMode));
         sl.add(new CheckBoxSetting(SettingsFile.KEY_USE_ASYNCHRONOUS_GPU_EMULATION, Settings.SECTION_RENDERER, R.string.asynchronous_gpu, R.string.asynchronous_gpu_description, true, useAsynchronousGpuEmulation));
         sl.add(new CheckBoxSetting(SettingsFile.KEY_SHADERS_ACCURATE_MUL, Settings.SECTION_RENDERER, R.string.shaders_accurate_mul, R.string.shaders_accurate_mul_description, false, shadersAccurateMul));
+        sl.add(new CheckBoxSetting(SettingsFile.KEY_USE_DISK_SHADER_CACHE, Settings.SECTION_RENDERER, R.string.use_disk_shader_cache, R.string.use_disk_shader_cache_description, true, useDiskShaderCache));
 
         sl.add(new HeaderSetting(null, null, R.string.stereoscopy, 0));
         sl.add(new SingleChoiceSetting(SettingsFile.KEY_RENDER_3D, Settings.SECTION_RENDERER, R.string.render3d, 0, R.array.render3dModes, R.array.render3dValues, 0, render3dMode));

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.java
@@ -43,6 +43,7 @@ public final class SettingsFile {
     public static final String KEY_HW_SHADER = "use_hw_shader";
     public static final String KEY_SHADERS_ACCURATE_MUL = "shaders_accurate_mul";
     public static final String KEY_USE_SHADER_JIT = "use_shader_jit";
+    public static final String KEY_USE_DISK_SHADER_CACHE = "use_disk_shader_cache";
     public static final String KEY_USE_VSYNC = "use_vsync_new";
     public static final String KEY_RESOLUTION_FACTOR = "resolution_factor";
     public static final String KEY_FRAME_LIMIT_ENABLED = "use_frame_limit";

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -124,7 +124,7 @@ void Config::ReadValues() {
     Settings::values.resolution_factor =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "resolution_factor", 1));
     Settings::values.use_disk_shader_cache =
-            sdl2_config->GetBoolean("Renderer", "use_disk_shader_cache", true);
+        sdl2_config->GetBoolean("Renderer", "use_disk_shader_cache", true);
     Settings::values.use_vsync_new = sdl2_config->GetBoolean("Renderer", "use_vsync_new", true);
 
     // Work around to map Android setting for enabling the frame limiter to the format Citra expects

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -123,6 +123,8 @@ void Config::ReadValues() {
     Settings::values.use_shader_jit = sdl2_config->GetBoolean("Renderer", "use_shader_jit", true);
     Settings::values.resolution_factor =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "resolution_factor", 1));
+    Settings::values.use_disk_shader_cache =
+            sdl2_config->GetBoolean("Renderer", "use_disk_shader_cache", true);
     Settings::values.use_vsync_new = sdl2_config->GetBoolean("Renderer", "use_vsync_new", true);
 
     // Work around to map Android setting for enabling the frame limiter to the format Citra expects

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -91,6 +91,12 @@ udp_pad_index=
 # 0: Interpreter (slow), 1 (default): JIT (fast)
 use_cpu_jit =
 
+# Change the Clock Frequency of the emulated 3DS CPU.
+# Underclocking can increase the performance of the game at the risk of freezing.
+# Overclocking may fix lag that happens on console, but also comes with the risk of freezing.
+# Range is any positive integer (but we suspect 25 - 400 is a good idea) Default is 100
+cpu_clock_percentage =
+
 [Renderer]
 # Whether to render using GLES or OpenGL
 # 0: OpenGL, 1 (default): GLES
@@ -104,6 +110,10 @@ use_hw_renderer =
 # 0: Software, 1 (default): Hardware
 use_hw_shader =
 
+# Whether to use separable shaders to emulate 3DS shaders (macOS only)
+# 0: Off (Default), 1 : On
+separable_shader =
+
 # Whether to use accurate multiplication in hardware shaders
 # 0: Off (Default. Faster, but causes issues in some games) 1: On (Slower, but correct)
 shaders_accurate_mul =
@@ -115,6 +125,15 @@ use_asynchronous_gpu_emulation =
 # Whether to use the Just-In-Time (JIT) compiler for shader emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)
 use_shader_jit =
+
+# Forces VSync on the display thread. Usually doesn't impact performance, but on some drivers it can
+# so only turn this off if you notice a speed difference.
+# 0: Off, 1 (default): On
+use_vsync_new =
+
+# Reduce stuttering by storing and loading generated shaders to disk
+# 0: Off, 1 (default. On)
+use_disk_shader_cache =
 
 # Resolution scale factor
 # 0: Auto (scales resolution to window size), 1: Native 3DS screen resolution, Otherwise a scale

--- a/src/android/app/src/main/jni/id_cache.cpp
+++ b/src/android/app/src/main/jni/id_cache.cpp
@@ -145,10 +145,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$SavestateInfo")));
     s_core_error_class = reinterpret_cast<jclass>(
         env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$CoreError")));
-    s_disk_cache_progress_class = reinterpret_cast<jclass>(
-        env->NewGlobalRef(env->FindClass("org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress")));
-    s_load_callback_stage_class = reinterpret_cast<jclass>(
-        env->NewGlobalRef(env->FindClass("org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage")));
+    s_disk_cache_progress_class = reinterpret_cast<jclass>(env->NewGlobalRef(
+        env->FindClass("org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress")));
+    s_load_callback_stage_class = reinterpret_cast<jclass>(env->NewGlobalRef(env->FindClass(
+        "org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage")));
 
     s_on_core_error = env->GetStaticMethodID(
         s_native_library_class, "OnCoreError",
@@ -169,8 +169,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         env->GetStaticMethodID(s_native_library_class, "RequestCameraPermission", "()Z");
     s_request_mic_permission =
         env->GetStaticMethodID(s_native_library_class, "RequestMicPermission", "()Z");
-    s_disk_cache_load_progress =
-        env->GetStaticMethodID(s_disk_cache_progress_class, "loadProgress", "(Lorg/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage;II)V");
+    s_disk_cache_load_progress = env->GetStaticMethodID(
+        s_disk_cache_progress_class, "loadProgress",
+        "(Lorg/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage;II)V");
 
     MiiSelector::InitJNI(env);
     SoftwareKeyboard::InitJNI(env);

--- a/src/android/app/src/main/jni/id_cache.cpp
+++ b/src/android/app/src/main/jni/id_cache.cpp
@@ -21,6 +21,8 @@ static JavaVM* s_java_vm;
 static jclass s_native_library_class;
 static jclass s_core_error_class;
 static jclass s_savestate_info_class;
+static jclass s_disk_cache_progress_class;
+static jclass s_load_callback_stage_class;
 static jmethodID s_on_core_error;
 static jmethodID s_display_alert_msg;
 static jmethodID s_display_alert_prompt;
@@ -30,6 +32,7 @@ static jmethodID s_landscape_screen_layout;
 static jmethodID s_exit_emulation_activity;
 static jmethodID s_request_camera_permission;
 static jmethodID s_request_mic_permission;
+static jmethodID s_disk_cache_load_progress;
 
 namespace IDCache {
 
@@ -62,6 +65,14 @@ jclass GetCoreErrorClass() {
 
 jclass GetSavestateInfoClass() {
     return s_savestate_info_class;
+}
+
+jclass GetDiskCacheProgressClass() {
+    return s_disk_cache_progress_class;
+}
+
+jclass GetDiskCacheLoadCallbackStageClass() {
+    return s_load_callback_stage_class;
 }
 
 jmethodID GetOnCoreError() {
@@ -100,6 +111,10 @@ jmethodID GetRequestMicPermission() {
     return s_request_mic_permission;
 }
 
+jmethodID GetDiskCacheLoadProgress() {
+    return s_disk_cache_load_progress;
+}
+
 } // namespace IDCache
 
 #ifdef __cplusplus
@@ -130,6 +145,11 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$SavestateInfo")));
     s_core_error_class = reinterpret_cast<jclass>(
         env->NewGlobalRef(env->FindClass("org/citra/citra_emu/NativeLibrary$CoreError")));
+    s_disk_cache_progress_class = reinterpret_cast<jclass>(
+        env->NewGlobalRef(env->FindClass("org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress")));
+    s_load_callback_stage_class = reinterpret_cast<jclass>(
+        env->NewGlobalRef(env->FindClass("org/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage")));
+
     s_on_core_error = env->GetStaticMethodID(
         s_native_library_class, "OnCoreError",
         "(Lorg/citra/citra_emu/NativeLibrary$CoreError;Ljava/lang/String;)Z");
@@ -149,6 +169,8 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         env->GetStaticMethodID(s_native_library_class, "RequestCameraPermission", "()Z");
     s_request_mic_permission =
         env->GetStaticMethodID(s_native_library_class, "RequestMicPermission", "()Z");
+    s_disk_cache_load_progress =
+        env->GetStaticMethodID(s_disk_cache_progress_class, "loadProgress", "(Lorg/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage;II)V");
 
     MiiSelector::InitJNI(env);
     SoftwareKeyboard::InitJNI(env);

--- a/src/android/app/src/main/jni/id_cache.h
+++ b/src/android/app/src/main/jni/id_cache.h
@@ -14,6 +14,8 @@ JNIEnv* GetEnvForThread();
 jclass GetNativeLibraryClass();
 jclass GetCoreErrorClass();
 jclass GetSavestateInfoClass();
+jclass GetDiskCacheProgressClass();
+jclass GetDiskCacheLoadCallbackStageClass();
 jmethodID GetOnCoreError();
 jmethodID GetDisplayAlertMsg();
 jmethodID GetDisplayAlertPrompt();
@@ -23,6 +25,7 @@ jmethodID GetLandscapeScreenLayout();
 jmethodID GetExitEmulationActivity();
 jmethodID GetRequestCameraPermission();
 jmethodID GetRequestMicPermission();
+jmethodID GetDiskCacheLoadProgress();
 
 } // namespace IDCache
 

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -140,7 +140,7 @@ static jobject ToJavaLoadCallbackStage(VideoCore::LoadCallbackStage stage) {
 
     JNIEnv* env = IDCache::GetEnvForThread();
 
-    const jclass load_callback_stage_class = IDCache::GetDiskCacheLoadCallbackStageClass();
+    jclass load_callback_stage_class = IDCache::GetDiskCacheLoadCallbackStageClass();
     return env->GetStaticObjectField(
         load_callback_stage_class,
         env->GetStaticFieldID(

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -228,8 +228,9 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
 
     LoadDiskCacheProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
 
-    std::unique_ptr<Frontend::GraphicsContext> cpu_context{window->CreateSharedContext()};
+    std::unique_ptr<Frontend::GraphicsContext> cpu_context;
     if (Settings::values.use_asynchronous_gpu_emulation) {
+        cpu_context = window->CreateSharedContext();
         cpu_context->MakeCurrent();
     }
 
@@ -237,6 +238,7 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
 
     if (Settings::values.use_asynchronous_gpu_emulation) {
         cpu_context->DoneCurrent();
+        cpu_context.reset();
     }
 
     LoadDiskCacheProgress(VideoCore::LoadCallbackStage::Complete, 0, 0);

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -121,10 +121,10 @@ static bool HandleCoreError(Core::System::ResultStatus result, const std::string
 
 static jobject ToJavaLoadCallbackStage(VideoCore::LoadCallbackStage stage) {
     static const std::map<VideoCore::LoadCallbackStage, const char*> LoadCallbackStageMap{
-            {VideoCore::LoadCallbackStage::Prepare, "Prepare"},
-            {VideoCore::LoadCallbackStage::Decompile, "Decompile"},
-            {VideoCore::LoadCallbackStage::Build, "Build"},
-            {VideoCore::LoadCallbackStage::Complete, "Complete"},
+        {VideoCore::LoadCallbackStage::Prepare, "Prepare"},
+        {VideoCore::LoadCallbackStage::Decompile, "Decompile"},
+        {VideoCore::LoadCallbackStage::Build, "Build"},
+        {VideoCore::LoadCallbackStage::Complete, "Complete"},
     };
 
     const auto name = LoadCallbackStageMap.at(stage);
@@ -133,13 +133,17 @@ static jobject ToJavaLoadCallbackStage(VideoCore::LoadCallbackStage stage) {
 
     const jclass load_callback_stage_class = IDCache::GetDiskCacheLoadCallbackStageClass();
     return env->GetStaticObjectField(
-            load_callback_stage_class, env->GetStaticFieldID(load_callback_stage_class, name,
-                                                    "Lorg/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage;"));
+        load_callback_stage_class,
+        env->GetStaticFieldID(
+            load_callback_stage_class, name,
+            "Lorg/citra/citra_emu/disk_shader_cache/DiskShaderCacheProgress$LoadCallbackStage;"));
 }
 
 static void LoadDiskCacheProgress(VideoCore::LoadCallbackStage stage, int progress, int max) {
     JNIEnv* env = IDCache::GetEnvForThread();
-    env->CallStaticVoidMethod(IDCache::GetDiskCacheProgressClass(), IDCache::GetDiskCacheLoadProgress(), ToJavaLoadCallbackStage(stage), (jint) progress, (jint) max);
+    env->CallStaticVoidMethod(IDCache::GetDiskCacheProgressClass(),
+                              IDCache::GetDiskCacheLoadProgress(), ToJavaLoadCallbackStage(stage),
+                              (jint)progress, (jint)max);
 }
 
 static Camera::NDK::Factory* g_ndk_factory{};
@@ -220,9 +224,7 @@ static Core::System::ResultStatus RunCitra(const std::string& filepath) {
         cpu_context->MakeCurrent();
     }
 
-    system.Renderer().Rasterizer()->LoadDiskResources(
-            !is_running, &LoadDiskCacheProgress
-            );
+    system.Renderer().Rasterizer()->LoadDiskResources(!is_running, &LoadDiskCacheProgress);
 
     if (Settings::values.use_asynchronous_gpu_emulation) {
         cpu_context->DoneCurrent();

--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -120,14 +120,23 @@ static bool HandleCoreError(Core::System::ResultStatus result, const std::string
 }
 
 static jobject ToJavaLoadCallbackStage(VideoCore::LoadCallbackStage stage) {
-    static const std::map<VideoCore::LoadCallbackStage, const char*> LoadCallbackStageMap{
-        {VideoCore::LoadCallbackStage::Prepare, "Prepare"},
-        {VideoCore::LoadCallbackStage::Decompile, "Decompile"},
-        {VideoCore::LoadCallbackStage::Build, "Build"},
-        {VideoCore::LoadCallbackStage::Complete, "Complete"},
-    };
-
-    const auto name = LoadCallbackStageMap.at(stage);
+    const char* name;
+    switch (stage) {
+    case VideoCore::LoadCallbackStage::Prepare:
+        name = "Prepare";
+        break;
+    case VideoCore::LoadCallbackStage::Decompile:
+        name = "Decompile";
+        break;
+    case VideoCore::LoadCallbackStage::Build:
+        name = "Build";
+        break;
+    case VideoCore::LoadCallbackStage::Complete:
+        name = "Complete";
+        break;
+    default:
+        UNREACHABLE();
+    }
 
     JNIEnv* env = IDCache::GetEnvForThread();
 

--- a/src/android/app/src/main/res/layout/dialog_progress_bar.xml
+++ b/src/android/app/src/main/res/layout/dialog_progress_bar.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/spacing_large"
+        android:layout_marginRight="@dimen/spacing_large"
+        android:layout_alignParentEnd="true"
+        android:layout_below="@+id/progress_text"
+        android:layout_alignParentStart="true"/>
+
+    <TextView
+        android:id="@+id/progress_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/spacing_large"
+        android:layout_marginRight="@dimen/spacing_large"
+        android:gravity="right"
+        android:text="1/100" />
+</LinearLayout>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -100,6 +100,9 @@
     <string name="cardboard_x_shift_description">Specifies the percentage of empty space to shift the screens horizontally. Positive values move the two eyes closer to the middle, while negative values move them away.</string>
     <string name="cardboard_y_shift">Vertical shift</string>
     <string name="cardboard_y_shift_description">Specifies the percentage of empty space to shift the screens vertically. Positive values move the two eyes towards the bottom, while negative values move them towards the top.</string>
+    <string name="use_shader_jit">Use shader JIT</string>
+    <string name="use_disk_shader_cache">Use disk shader cache</string>
+    <string name="use_disk_shader_cache_description">Reduce stuttering by storing and loading generated shaders to disk. It cannot be used without Enabling Hardware Shader.</string>
 
     <!-- Premium strings -->
     <string name="premium_text">Premium</string>
@@ -119,6 +122,7 @@
     <string name="ini_saved">Saved settings</string>
     <string name="gameid_saved">Saved settings for %1$s</string>
     <string name="error_saving">Error saving %1$s.ini: %2$s</string>
+    <string name="loading">Loading...</string>
 
     <!-- Game Grid Screen-->
     <string name="grid_menu_core_settings">Settings</string>
@@ -215,4 +219,8 @@
     <string name="save_load_error">Save/Load Error</string>
     <string name="fatal_error">Fatal Error</string>
     <string name="fatal_error_message">A fatal error occurred. Check the log for details.\nContinuing emulation may result in crashes and bugs.</string>
+
+    <!-- Disk shader cache -->
+    <string name="preparing_shaders">Preparing shaders</string>
+    <string name="building_shaders">Building shaders</string>
 </resources>

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -24,7 +24,7 @@ void RendererBase::RefreshRasterizerSetting() {
         opengl_rasterizer_active = hw_renderer_enabled;
 
         if (hw_renderer_enabled) {
-            rasterizer = std::make_unique<OpenGL::RasterizerOpenGL>();
+            rasterizer = std::make_unique<OpenGL::RasterizerOpenGL>(render_window);
         } else {
             rasterizer = std::make_unique<VideoCore::SWRasterizer>();
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -48,7 +48,7 @@ static bool IsVendorIntel() {
     return gpu_vendor == "Intel Inc.";
 }
 
-RasterizerOpenGL::RasterizerOpenGL()
+RasterizerOpenGL::RasterizerOpenGL(Frontend::EmuWindow& emu_window)
     : is_amd(IsVendorAmd()), vertex_buffer(GL_ARRAY_BUFFER, VERTEX_BUFFER_SIZE, is_amd),
       uniform_buffer(GL_UNIFORM_BUFFER, UNIFORM_BUFFER_SIZE, false),
       index_buffer(GL_ELEMENT_ARRAY_BUFFER, INDEX_BUFFER_SIZE, false),
@@ -166,16 +166,16 @@ RasterizerOpenGL::RasterizerOpenGL()
 
 #ifdef __APPLE__
     if (IsVendorIntel()) {
-        shader_program_manager = std::make_unique<ShaderProgramManager>(
+        shader_program_manager = std::make_unique<ShaderProgramManager>(emu_window,
             VideoCore::g_separable_shader_enabled ? GLAD_GL_ARB_separate_shader_objects : false,
             is_amd);
     } else {
         shader_program_manager =
-            std::make_unique<ShaderProgramManager>(GLAD_GL_ARB_separate_shader_objects, is_amd);
+            std::make_unique<ShaderProgramManager>(emu_window, GLAD_GL_ARB_separate_shader_objects, is_amd);
     }
 #else
     shader_program_manager =
-        std::make_unique<ShaderProgramManager>(GLAD_GL_ARB_separate_shader_objects, is_amd);
+        std::make_unique<ShaderProgramManager>(emu_window, GLAD_GL_ARB_separate_shader_objects, is_amd);
 #endif
 
     glEnable(GL_BLEND);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -166,16 +166,17 @@ RasterizerOpenGL::RasterizerOpenGL(Frontend::EmuWindow& emu_window)
 
 #ifdef __APPLE__
     if (IsVendorIntel()) {
-        shader_program_manager = std::make_unique<ShaderProgramManager>(emu_window,
+        shader_program_manager = std::make_unique<ShaderProgramManager>(
+            emu_window,
             VideoCore::g_separable_shader_enabled ? GLAD_GL_ARB_separate_shader_objects : false,
             is_amd);
     } else {
-        shader_program_manager =
-            std::make_unique<ShaderProgramManager>(emu_window, GLAD_GL_ARB_separate_shader_objects, is_amd);
+        shader_program_manager = std::make_unique<ShaderProgramManager>(
+            emu_window, GLAD_GL_ARB_separate_shader_objects, is_amd);
     }
 #else
-    shader_program_manager =
-        std::make_unique<ShaderProgramManager>(emu_window, GLAD_GL_ARB_separate_shader_objects, is_amd);
+    shader_program_manager = std::make_unique<ShaderProgramManager>(
+        emu_window, GLAD_GL_ARB_separate_shader_objects, is_amd);
 #endif
 
     glEnable(GL_BLEND);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -38,7 +38,7 @@ class ShaderProgramManager;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
-    explicit RasterizerOpenGL();
+    explicit RasterizerOpenGL(Frontend::EmuWindow& emu_window);
     ~RasterizerOpenGL() override;
 
     void LoadDiskResources(const std::atomic_bool& stop_loading,

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -106,7 +106,7 @@ ShaderDiskCache::ShaderDiskCache(bool separable) : separable{separable} {}
 
 std::optional<std::vector<ShaderDiskCacheRaw>> ShaderDiskCache::LoadTransferable() {
     const bool has_title_id = GetProgramID() != 0;
-    if (!Settings::values.use_hw_shader || !Settings::values.shaders_accurate_mul ||
+    if (!Settings::values.use_hw_shader ||
         !Settings::values.use_disk_shader_cache || !has_title_id) {
         return std::nullopt;
     }
@@ -171,7 +171,7 @@ std::optional<std::vector<ShaderDiskCacheRaw>> ShaderDiskCache::LoadTransferable
 }
 
 std::pair<std::unordered_map<u64, ShaderDiskCacheDecompiled>, ShaderDumpsMap>
-ShaderDiskCache::LoadPrecompiled() {
+ShaderDiskCache::LoadPrecompiled(bool compressed) {
     if (!IsUsable())
         return {};
 
@@ -182,7 +182,7 @@ ShaderDiskCache::LoadPrecompiled() {
         return {};
     }
 
-    const auto result = LoadPrecompiledFile(file);
+    const auto result = LoadPrecompiledFile(file, compressed);
     if (!result) {
         LOG_INFO(Render_OpenGL,
                  "Failed to load precompiled cache for game with title id={} - removing",
@@ -195,12 +195,17 @@ ShaderDiskCache::LoadPrecompiled() {
 }
 
 std::optional<std::pair<std::unordered_map<u64, ShaderDiskCacheDecompiled>, ShaderDumpsMap>>
-ShaderDiskCache::LoadPrecompiledFile(FileUtil::IOFile& file) {
+ShaderDiskCache::LoadPrecompiledFile(FileUtil::IOFile& file, bool compressed) {
     // Read compressed file from disk and decompress to virtual precompiled cache file
-    std::vector<u8> compressed(file.GetSize());
-    file.ReadBytes(compressed.data(), compressed.size());
-    const std::vector<u8> decompressed = Common::Compression::DecompressDataZSTD(compressed);
-    SaveArrayToPrecompiled(decompressed.data(), decompressed.size());
+    std::vector<u8> precompiled_file(file.GetSize());
+    file.ReadBytes(precompiled_file.data(), precompiled_file.size());
+    if (compressed) {
+        const std::vector<u8> decompressed = Common::Compression::DecompressDataZSTD(precompiled_file);
+        SaveArrayToPrecompiled(decompressed.data(), decompressed.size());
+    } else {
+        SaveArrayToPrecompiled(precompiled_file.data(), precompiled_file.size());
+    }
+
     decompressed_precompiled_cache_offset = 0;
 
     ShaderCacheVersionHash file_hash{};
@@ -293,9 +298,26 @@ std::optional<ShaderDiskCacheDecompiled> ShaderDiskCache::LoadDecompiledEntry() 
     return entry;
 }
 
-bool ShaderDiskCache::SaveDecompiledFile(u64 unique_identifier,
-                                         const ShaderDecompiler::ProgramResult& result,
-                                         bool sanitize_mul) {
+void ShaderDiskCache::SaveDecompiledToFile(FileUtil::IOFile& file, u64 unique_identifier,
+                                            const ShaderDecompiler::ProgramResult& result,
+                                            bool sanitize_mul) {
+    if (!IsUsable())
+        return;
+
+    if (file.WriteObject(static_cast<u32>(PrecompiledEntryKind::Decompiled)) != 1 ||
+        file.WriteObject(unique_identifier) != 1 ||
+        file.WriteObject(sanitize_mul) != 1 ||
+        file.WriteObject(static_cast<u32>(result.code.size())) != 1 ||
+        file.WriteArray(result.code.data(), result.code.size()) != result.code.size()) {
+        LOG_ERROR(Render_OpenGL, "Failed to save decompiled cache entry - removing");
+        file.Close();
+        InvalidatePrecompiled();
+    }
+}
+
+bool ShaderDiskCache::SaveDecompiledToCache(u64 unique_identifier,
+                                            const ShaderDecompiler::ProgramResult& result,
+                                            bool sanitize_mul) {
     if (!SaveObjectToPrecompiled(static_cast<u32>(PrecompiledEntryKind::Decompiled)) ||
         !SaveObjectToPrecompiled(unique_identifier) || !SaveObjectToPrecompiled(sanitize_mul) ||
         !SaveObjectToPrecompiled(static_cast<u32>(result.code.size())) ||
@@ -315,7 +337,7 @@ void ShaderDiskCache::InvalidateAll() {
 }
 
 void ShaderDiskCache::InvalidatePrecompiled() {
-    // Clear virtaul precompiled cache file
+    // Clear virtual precompiled cache file
     decompressed_precompiled_cache.resize(0);
 
     if (!FileUtil::Delete(GetPrecompiledPath())) {
@@ -351,11 +373,11 @@ void ShaderDiskCache::SaveDecompiled(u64 unique_identifier,
     if (!IsUsable())
         return;
 
-    if (decompressed_precompiled_cache.size() == 0) {
+    if (decompressed_precompiled_cache.empty()) {
         SavePrecompiledHeaderToVirtualPrecompiledCache();
     }
 
-    if (!SaveDecompiledFile(unique_identifier, code, sanitize_mul)) {
+    if (!SaveDecompiledToCache(unique_identifier, code, sanitize_mul)) {
         LOG_ERROR(Render_OpenGL,
                   "Failed to save decompiled entry to the precompiled file - removing");
         InvalidatePrecompiled();
@@ -368,6 +390,9 @@ void ShaderDiskCache::SaveDump(u64 unique_identifier, GLuint program) {
 
     GLint binary_length{};
     glGetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binary_length);
+
+    if (!binary_length)
+        return;
 
     GLenum binary_format{};
     std::vector<u8> binary(binary_length);
@@ -383,6 +408,40 @@ void ShaderDiskCache::SaveDump(u64 unique_identifier, GLuint program) {
         InvalidatePrecompiled();
         return;
     }
+}
+
+void ShaderDiskCache::SaveDumpToFile(u64 unique_identifier, GLuint program, bool sanitize_mul) {
+    if (!IsUsable())
+        return;
+
+    FileUtil::IOFile file = AppendPrecompiledFile();
+    if (!file.IsOpen())
+        return;
+
+    GLint binary_length{};
+    glGetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binary_length);
+
+    if (!binary_length)
+        return;
+
+    GLenum binary_format{};
+    std::vector<u8> binary(binary_length);
+    glGetProgramBinary(program, binary_length, nullptr, &binary_format, binary.data());
+
+    if (file.WriteObject(static_cast<u32>(PrecompiledEntryKind::Dump)) != 1 ||
+        file.WriteObject(unique_identifier) != 1 ||
+        file.WriteObject(static_cast<u32>(binary_format)) != 1 ||
+        file.WriteObject(static_cast<u32>(binary_length)) != 1||
+        file.WriteArray(binary.data(), binary.size()) != binary.size()) {
+        LOG_ERROR(Render_OpenGL, "Failed to save binary program file in shader={:016x} - removing",
+                  unique_identifier);
+        InvalidatePrecompiled();
+        return;
+    }
+
+    // SaveDecompiled is used only to store the accurate multiplication setting, a better way is to
+    // probably change the header in SaveDump
+    SaveDecompiledToFile(file, unique_identifier, {}, sanitize_mul);
 }
 
 bool ShaderDiskCache::IsUsable() const {
@@ -406,6 +465,30 @@ FileUtil::IOFile ShaderDiskCache::AppendTransferableFile() {
         if (file.WriteObject(NativeVersion) != 1) {
             LOG_ERROR(Render_OpenGL, "Failed to write transferable cache version in path={}",
                       transferable_path);
+            return {};
+        }
+    }
+    return file;
+}
+
+FileUtil::IOFile ShaderDiskCache::AppendPrecompiledFile() {
+    if (!EnsureDirectories())
+        return {};
+
+    const auto precompiled_path{GetPrecompiledPath()};
+    const bool existed = FileUtil::Exists(precompiled_path);
+
+    FileUtil::IOFile file(precompiled_path, "ab");
+    if (!file.IsOpen()) {
+        LOG_ERROR(Render_OpenGL, "Failed to open precompiled cache in path={}", precompiled_path);
+        return {};
+    }
+    if (!existed || file.GetSize() == 0) {
+        // If the file didn't exist, write its version
+        const auto hash{GetShaderCacheVersionHash()};
+        if (file.WriteArray(hash.data(), hash.size()) != hash.size()) {
+            LOG_ERROR(Render_OpenGL, "Failed to write precompiled cache version in path={}",
+                      precompiled_path);
             return {};
         }
     }

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -534,7 +534,7 @@ bool ShaderDiskCache::EnsureDirectories() const {
 
     return CreateDir(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir)) &&
            CreateDir(GetBaseDir()) && CreateDir(GetTransferableDir()) &&
-           CreateDir(GetPrecompiledDir());
+           CreateDir(GetPrecompiledDir()) && CreateDir(GetPrecompiledShaderDir());
 }
 
 std::string ShaderDiskCache::GetTransferablePath() {
@@ -542,7 +542,7 @@ std::string ShaderDiskCache::GetTransferablePath() {
 }
 
 std::string ShaderDiskCache::GetPrecompiledPath() {
-    return FileUtil::SanitizePath(GetPrecompiledDir() + DIR_SEP_CHR + GetTitleID() + ".bin");
+    return FileUtil::SanitizePath(GetPrecompiledShaderDir() + DIR_SEP_CHR + GetTitleID() + ".bin");
 }
 
 std::string ShaderDiskCache::GetTransferableDir() const {
@@ -551,6 +551,13 @@ std::string ShaderDiskCache::GetTransferableDir() const {
 
 std::string ShaderDiskCache::GetPrecompiledDir() const {
     return GetBaseDir() + DIR_SEP "precompiled";
+}
+
+std::string ShaderDiskCache::GetPrecompiledShaderDir() const {
+    if (separable) {
+        return GetPrecompiledDir() + DIR_SEP "separable";
+    }
+    return GetPrecompiledDir() + DIR_SEP "conventional";
 }
 
 std::string ShaderDiskCache::GetBaseDir() const {

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -106,8 +106,8 @@ ShaderDiskCache::ShaderDiskCache(bool separable) : separable{separable} {}
 
 std::optional<std::vector<ShaderDiskCacheRaw>> ShaderDiskCache::LoadTransferable() {
     const bool has_title_id = GetProgramID() != 0;
-    if (!Settings::values.use_hw_shader ||
-        !Settings::values.use_disk_shader_cache || !has_title_id) {
+    if (!Settings::values.use_hw_shader || !Settings::values.use_disk_shader_cache ||
+        !has_title_id) {
         return std::nullopt;
     }
     tried_to_load = true;
@@ -200,7 +200,8 @@ ShaderDiskCache::LoadPrecompiledFile(FileUtil::IOFile& file, bool compressed) {
     std::vector<u8> precompiled_file(file.GetSize());
     file.ReadBytes(precompiled_file.data(), precompiled_file.size());
     if (compressed) {
-        const std::vector<u8> decompressed = Common::Compression::DecompressDataZSTD(precompiled_file);
+        const std::vector<u8> decompressed =
+            Common::Compression::DecompressDataZSTD(precompiled_file);
         SaveArrayToPrecompiled(decompressed.data(), decompressed.size());
     } else {
         SaveArrayToPrecompiled(precompiled_file.data(), precompiled_file.size());
@@ -299,14 +300,13 @@ std::optional<ShaderDiskCacheDecompiled> ShaderDiskCache::LoadDecompiledEntry() 
 }
 
 void ShaderDiskCache::SaveDecompiledToFile(FileUtil::IOFile& file, u64 unique_identifier,
-                                            const ShaderDecompiler::ProgramResult& result,
-                                            bool sanitize_mul) {
+                                           const ShaderDecompiler::ProgramResult& result,
+                                           bool sanitize_mul) {
     if (!IsUsable())
         return;
 
     if (file.WriteObject(static_cast<u32>(PrecompiledEntryKind::Decompiled)) != 1 ||
-        file.WriteObject(unique_identifier) != 1 ||
-        file.WriteObject(sanitize_mul) != 1 ||
+        file.WriteObject(unique_identifier) != 1 || file.WriteObject(sanitize_mul) != 1 ||
         file.WriteObject(static_cast<u32>(result.code.size())) != 1 ||
         file.WriteArray(result.code.data(), result.code.size()) != result.code.size()) {
         LOG_ERROR(Render_OpenGL, "Failed to save decompiled cache entry - removing");
@@ -431,7 +431,7 @@ void ShaderDiskCache::SaveDumpToFile(u64 unique_identifier, GLuint program, bool
     if (file.WriteObject(static_cast<u32>(PrecompiledEntryKind::Dump)) != 1 ||
         file.WriteObject(unique_identifier) != 1 ||
         file.WriteObject(static_cast<u32>(binary_format)) != 1 ||
-        file.WriteObject(static_cast<u32>(binary_length)) != 1||
+        file.WriteObject(static_cast<u32>(binary_length)) != 1 ||
         file.WriteArray(binary.data(), binary.size()) != binary.size()) {
         LOG_ERROR(Render_OpenGL, "Failed to save binary program file in shader={:016x} - removing",
                   unique_identifier);

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -131,8 +131,8 @@ private:
     std::optional<ShaderDiskCacheDecompiled> LoadDecompiledEntry();
 
     /// Saves a decompiled entry to the passed file. Does not check for collisions.
-    void SaveDecompiledToFile(FileUtil::IOFile& file, u64 unique_identifier, const ShaderDecompiler::ProgramResult& code,
-                              bool sanitize_mul);
+    void SaveDecompiledToFile(FileUtil::IOFile& file, u64 unique_identifier,
+                              const ShaderDecompiler::ProgramResult& code, bool sanitize_mul);
 
     /// Saves a decompiled entry to the virtual precompiled cache. Does not check for collisions.
     bool SaveDecompiledToCache(u64 unique_identifier, const ShaderDecompiler::ProgramResult& code,

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -162,6 +162,8 @@ private:
     /// Get user's precompiled directory path
     std::string GetPrecompiledDir() const;
 
+    std::string GetPrecompiledShaderDir() const;
+
     /// Get user's shader directory path
     std::string GetBaseDir() const;
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -97,7 +97,7 @@ public:
     std::optional<std::vector<ShaderDiskCacheRaw>> LoadTransferable();
 
     /// Loads current game's precompiled cache. Invalidates on failure.
-    std::pair<ShaderDecompiledMap, ShaderDumpsMap> LoadPrecompiled();
+    std::pair<ShaderDecompiledMap, ShaderDumpsMap> LoadPrecompiled(bool compressed);
 
     /// Removes the transferable (and precompiled) cache file.
     void InvalidateAll();
@@ -115,21 +115,28 @@ public:
     /// Saves a dump entry to the precompiled file. Does not check for collisions.
     void SaveDump(u64 unique_identifier, GLuint program);
 
+    /// Saves a dump entry to the precompiled file. Does not check for collisions.
+    void SaveDumpToFile(u64 unique_identifier, GLuint program, bool sanitize_mul);
+
     /// Serializes virtual precompiled shader cache file to real file
     void SaveVirtualPrecompiledFile();
 
 private:
     /// Loads the transferable cache. Returns empty on failure.
     std::optional<std::pair<ShaderDecompiledMap, ShaderDumpsMap>> LoadPrecompiledFile(
-        FileUtil::IOFile& file);
+        FileUtil::IOFile& file, bool compressed);
 
     /// Loads a decompiled cache entry from m_precompiled_cache_virtual_file. Returns empty on
     /// failure.
     std::optional<ShaderDiskCacheDecompiled> LoadDecompiledEntry();
 
-    /// Saves a decompiled entry to the passed file. Returns true on success.
-    bool SaveDecompiledFile(u64 unique_identifier, const ShaderDecompiler::ProgramResult& code,
-                            bool sanitize_mul);
+    /// Saves a decompiled entry to the passed file. Does not check for collisions.
+    void SaveDecompiledToFile(FileUtil::IOFile& file, u64 unique_identifier, const ShaderDecompiler::ProgramResult& code,
+                              bool sanitize_mul);
+
+    /// Saves a decompiled entry to the virtual precompiled cache. Does not check for collisions.
+    bool SaveDecompiledToCache(u64 unique_identifier, const ShaderDecompiler::ProgramResult& code,
+                               bool sanitize_mul);
 
     /// Returns if the cache can be used
     bool IsUsable() const;
@@ -197,7 +204,7 @@ private:
         return LoadArrayFromPrecompiled(&object, 1);
     }
 
-    // Stores whole precompiled cache which will be read from or saved to the precompiled chache
+    // Stores whole precompiled cache which will be read from or saved to the precompiled cache
     // file
     std::vector<u8> decompressed_precompiled_cache;
     // Stores the current offset of the precompiled cache file for IO purposes
@@ -213,6 +220,8 @@ private:
 
     u64 program_id{};
     std::string title_id;
+
+    FileUtil::IOFile AppendPrecompiledFile();
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -482,11 +482,6 @@ void ShaderProgramManager::ApplyTo(OpenGLState& state) {
 
 void ShaderProgramManager::LoadDiskCache(const std::atomic_bool& stop_loading,
                                          const VideoCore::DiskResourceLoadCallback& callback) {
-    if (!impl->separable) {
-        LOG_ERROR(Render_OpenGL,
-                  "Cannot load disk cache as separate shader programs are unsupported!");
-//        return;
-    }
     auto& disk_cache = impl->disk_cache;
     const auto transferable = disk_cache.LoadTransferable();
     if (!transferable) {

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -99,7 +99,7 @@ static_assert(sizeof(VSUniformData) < 16384,
 /// A class that manage different shader stages and configures them with given config data.
 class ShaderProgramManager {
 public:
-    ShaderProgramManager(bool separable, bool is_amd);
+    ShaderProgramManager(Frontend::EmuWindow& emu_window_, bool separable, bool is_amd);
     ~ShaderProgramManager();
 
     void LoadDiskCache(const std::atomic_bool& stop_loading,
@@ -120,5 +120,7 @@ public:
 private:
     class Impl;
     std::unique_ptr<Impl> impl;
+
+    Frontend::EmuWindow& emu_window;
 };
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -84,6 +84,7 @@ GLuint LoadProgram(bool separable_program, const std::vector<GLuint>& shaders) {
         glProgramParameteri(program_id, GL_PROGRAM_SEPARABLE, GL_TRUE);
     }
 
+    glProgramParameteri(program_id, GL_PROGRAM_BINARY_RETRIEVABLE_HINT, GL_TRUE);
     glLinkProgram(program_id);
 
     // Check the program


### PR DESCRIPTION
Adds disk cache for conventional/non-separable shaders, additionally add multi-threading for loading the Transferable cache, likely adds additional load time on desktop, since we don't check if the precompiled shader is already present in the cache (I'll probably address that in a later PR).

The progress dialog implementation feels jank atm, so if anyone knows a better way I would appreciate it.
